### PR TITLE
Reduce verbosity of StatelessCSRFTokenManager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.salesforce.sld4j</groupId>
 	<artifactId>sld4j</artifactId>
-	<version>1.1.0-SNAPSHOT</version>
+	<version>1.1.1-SNAPSHOT</version>
 
 	<name>SLD4J</name>
 	<description>Secure Libraries for Developers</description>

--- a/src/main/java/com/salesforce/sld/csrf/StatelessCSRFTokenManager.java
+++ b/src/main/java/com/salesforce/sld/csrf/StatelessCSRFTokenManager.java
@@ -351,7 +351,7 @@ public class StatelessCSRFTokenManager
     public boolean validateToken( String token, String sessionID, String... otherData )
         throws IllegalArgumentException
     {
-        if ( token == null )
+        if ( token == null || token.length() == 0)
         {
             this.handler.handleInternalError( "CSRF token does not exist" );
             return false;


### PR DESCRIPTION
The current implementation is very verbose when an empty CSRF token is passed to be validated.
It throws and Exception that gets logged with the full stack trace.
This case is common for applications that first use CSRF protection.
The change in this PR will reduce the verbosity of this error case and make it consistent with the current behavior when a null CSRF token is passed.
Ultimately, this behavior is configurable for more mature applications. They can (and should) implement a custom ICSRFErrorHandler.